### PR TITLE
Added name to layout xml for callbackform

### DIFF
--- a/view/frontend/layout/sdmaltapay_index_callbackform.xml
+++ b/view/frontend/layout/sdmaltapay_index_callbackform.xml
@@ -7,8 +7,8 @@
     </head>
     <body>
         <referenceContainer name="content">
-            <block class="Magento\Framework\View\Element\Template" template="SDM_Altapay::callbackform.phtml"/>
-            <block class="SDM\Altapay\Block\Callback\Ordersummary" template="SDM_Altapay::ordersummary.phtml"/>
+            <block class="Magento\Framework\View\Element\Template" template="SDM_Altapay::callbackform.phtml" name="sdm_altapay_callback_form"/>
+            <block class="SDM\Altapay\Block\Callback\Ordersummary" template="SDM_Altapay::ordersummary.phtml" name="sdm_altapay_callback_ordersummary"/>
         </referenceContainer>
     </body>
 </page>


### PR DESCRIPTION
This is an issue when the module fails in rendering this, it is not possible to rewrite and remove ordersummary without a name to reference on